### PR TITLE
Makes it no longer crash or be nonresponsive about the column, row and shape amount.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ buildPackage.*/
 linux-amd64/
 windows-amd64/
 
+# Processing IDE
+*.autosave
+
 # Processing IDE Java/Android Mode file
 sketch.properties
 

--- a/Option.pde
+++ b/Option.pde
@@ -58,14 +58,14 @@ abstract class UpOptionButton extends OptionButton {
 class ColsOption extends Option {
   class ColsDownButton extends DownOptionButton {
     void onClick() {
-      GRID_COLUMNS = max(GRID_COLUMNS - 1, max(1, SHAPES_COUNT/GRID_ROWS));
+      applyConstraints(-1, 0, 0);
       grid = null;
     }
   }
 
   class ColsUpButton extends UpOptionButton {
     void onClick() {
-      GRID_COLUMNS = max(GRID_COLUMNS + 1, max(1, SHAPES_COUNT/GRID_ROWS));
+      applyConstraints(1, 0, 0);
       grid = null;
     }
   }
@@ -80,14 +80,14 @@ class ColsOption extends Option {
 class RowsOption extends Option {
   class RowsDownButton extends DownOptionButton {
     void onClick() {
-      GRID_ROWS = max(GRID_ROWS - 1, max(1, SHAPES_COUNT/GRID_COLUMNS));
+      applyConstraints(0, -1, 0);
       grid = null;
     }
   }
 
   class RowsUpButton extends UpOptionButton {
     void onClick() {
-      GRID_ROWS = max(GRID_ROWS + 1, max(1, SHAPES_COUNT/GRID_COLUMNS));
+      applyConstraints(0, 1, 0);
       grid = null;
     }
   }
@@ -102,14 +102,14 @@ class RowsOption extends Option {
 class ShapesOption extends Option {
   class ShapesDownButton extends DownOptionButton {
     void onClick() {
-      SHAPES_COUNT = constrain(SHAPES_COUNT - 1, 1, GRID_ROWS*GRID_COLUMNS);
+      applyConstraints(0, 0, -1);
       grid = null;
     }
   }
 
   class ShapesUpButton extends UpOptionButton {
     void onClick() {
-      SHAPES_COUNT = constrain(SHAPES_COUNT + 1, 1, GRID_ROWS*GRID_COLUMNS);
+      applyConstraints(0, 0, 1);
       grid = null;
     }
   }
@@ -118,5 +118,19 @@ class ShapesOption extends Option {
     super("Shapes", 2);
     downButton = new ShapesDownButton();
     upButton = new ShapesUpButton();
+  }
+}
+
+void applyConstraints(int colChange, int rowChange, int shapesCountChange) {
+  if (shapesCountChange != 0) {
+    SHAPES_COUNT = max(1, SHAPES_COUNT + shapesCountChange);
+    if (SHAPES_COUNT > GRID_COLUMNS*GRID_ROWS) {
+      if (GRID_COLUMNS > GRID_ROWS) GRID_ROWS += 1;
+      else GRID_COLUMNS += 1;
+    }
+  } else {
+    GRID_COLUMNS = max(1, GRID_COLUMNS + colChange);
+    GRID_ROWS = max(1, GRID_ROWS + rowChange);
+    SHAPES_COUNT = constrain(SHAPES_COUNT, 1, GRID_COLUMNS*GRID_ROWS);
   }
 }

--- a/Option.pde
+++ b/Option.pde
@@ -58,14 +58,14 @@ abstract class UpOptionButton extends OptionButton {
 class ColsOption extends Option {
   class ColsDownButton extends DownOptionButton {
     void onClick() {
-      GRID_COLUMNS--;
+      GRID_COLUMNS = max(GRID_COLUMNS - 1, max(1, SHAPES_COUNT/GRID_ROWS));
       grid = null;
     }
   }
 
   class ColsUpButton extends UpOptionButton {
     void onClick() {
-      GRID_COLUMNS++;
+      GRID_COLUMNS = max(GRID_COLUMNS + 1, max(1, SHAPES_COUNT/GRID_ROWS));
       grid = null;
     }
   }
@@ -80,14 +80,14 @@ class ColsOption extends Option {
 class RowsOption extends Option {
   class RowsDownButton extends DownOptionButton {
     void onClick() {
-      GRID_ROWS--;
+      GRID_ROWS = max(GRID_ROWS - 1, max(1, SHAPES_COUNT/GRID_COLUMNS));
       grid = null;
     }
   }
 
   class RowsUpButton extends UpOptionButton {
     void onClick() {
-      GRID_ROWS++;
+      GRID_ROWS = max(GRID_ROWS + 1, max(1, SHAPES_COUNT/GRID_COLUMNS));
       grid = null;
     }
   }
@@ -102,14 +102,14 @@ class RowsOption extends Option {
 class ShapesOption extends Option {
   class ShapesDownButton extends DownOptionButton {
     void onClick() {
-      SHAPES_COUNT--;
+      SHAPES_COUNT = constrain(SHAPES_COUNT - 1, 1, GRID_ROWS*GRID_COLUMNS);
       grid = null;
     }
   }
 
   class ShapesUpButton extends UpOptionButton {
     void onClick() {
-      SHAPES_COUNT++;
+      SHAPES_COUNT = constrain(SHAPES_COUNT + 1, 1, GRID_ROWS*GRID_COLUMNS);
       grid = null;
     }
   }


### PR DESCRIPTION
I added a function that applies constraints to the given values, to avoid having more shapes than cells, as well as to avoid negative shapes or cells.
If the shape count is changed beyond what the grid supports, the row and column amounts will adjust to make it fit (towards a square).
If the row and column amounts are changed beyond what the shape count supports, the shape count is simply clamped.